### PR TITLE
Fixed wrongly used L1 web3signer for L2 tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "catalyst_node"
-version = "0.2.118"
+version = "0.2.119"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-boot-node"
-version = "0.2.118"
+version = "0.2.119"
 dependencies = [
  "anyhow",
  "discv5",
@@ -4953,7 +4953,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-network"
-version = "0.2.118"
+version = "0.2.119"
 dependencies = [
  "discv5",
  "futures",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-node"
-version = "0.2.118"
+version = "0.2.119"
 dependencies = [
  "anyhow",
  "jsonrpsee",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 default-members = ["node"]
 
 [workspace.package]
-version = "0.2.118"
+version = "0.2.119"
 edition = "2024"
 repository = "https://github.com/NethermindEth/Catalyst"
 license = "MIT"

--- a/node/src/shared/web3signer.rs
+++ b/node/src/shared/web3signer.rs
@@ -27,6 +27,7 @@ impl Web3Signer {
         timeout: Duration,
         signer_address: &str,
     ) -> Result<Self, Error> {
+        info!("Web3Signer: Creating new Web3Signer with URL: {}", rpc_url);
         let client = JSONRPCClient::new_with_timeout(rpc_url, timeout)?;
         if !Self::is_signer_key_available(&client, signer_address).await? {
             return Err(anyhow::anyhow!(

--- a/node/src/utils/config.rs
+++ b/node/src/utils/config.rs
@@ -409,11 +409,11 @@ impl Config {
         info!(
             r#"
 Configuration:{}
-Taiko geth WS RPC URL: {},
+Taiko geth L2 RPC URL: {},
 Taiko geth auth RPC URL: {},
 Taiko driver URL: {},
 MEV Boost URL: {},
-L1 WS URL: {},
+L1 RPC URL: {},
 Consensus layer URL: {},
 Web3signer L1 URL: {},
 Web3signer L2 URL: {},


### PR DESCRIPTION
The same object was used for both L1 and L2 transactions signing. Separated them so we use different web3signer instances with different chain ids.