### PR TITLE
Add error code for non-preconfer

### DIFF
--- a/node/src/ethereum_l1/tools.rs
+++ b/node/src/ethereum_l1/tools.rs
@@ -28,10 +28,11 @@ pub fn check_oldest_forced_inclusion_due(err_str: &str) -> bool {
 
 // 0x47fac6c1 -> NotTheOperator()
 // 0x795e2f19 -> NotPreconfer()
+// 0xc0ec4b50 -> NotPreconferOrFallback()
 pub fn check_for_not_the_operator_in_current_epoch(err_str: &str) -> bool {
     // TODO: for new contracts version we should remove NotTheOperator
     // as it was renamed to NotPreconfer
-    err_str.contains("0x47fac6c1") || err_str.contains("0x795e2f19")
+    err_str.contains("0x47fac6c1") || err_str.contains("0x795e2f19") || err_str.contains("0xc0ec4b50")
 }
 
 pub fn convert_error_payload(err: &str) -> Option<TransactionError> {


### PR DESCRIPTION
Looking at mainnet logs we are sometimes triggering shutdown due to `0xc0ec4b50 -> NotPreconferOrFallback()`. In past 12 hours it happened [two times](https://nethermind.grafana.net/explore?schemaVersion=1&panes=%7B%22mam%22:%7B%22datasource%22:%22cecof6jqk6ozkd%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22research-taiko-preconfer%5C%22,%20instance%3D%5C%22preconfer%5C%22%7D%20%7C%3D%20%60Shutdown%60%20or%20%60execution%20reverted%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22cecof6jqk6ozkd%22%7D,%22editorMode%22:%22builder%22,%22direction%22:%22backward%22,%22maxLines%22:5000%7D%5D,%22range%22:%7B%22from%22:%22now-24h%22,%22to%22:%22now%22%7D,%22panelsState%22:%7B%22logs%22:%7B%22visualisationType%22:%22logs%22,%22columns%22:%5B%22Time%22,%22Line%22%5D,%22labelFieldName%22:%22labels%22%7D%7D,%22compact%22:false%7D%7D&orgId=1&chunkNotFound=true).