### PR TITLE
fix test_verify_forced_inclusion_after_previous_operator_stop

### DIFF
--- a/e2e_tests/test_avs_node.py
+++ b/e2e_tests/test_avs_node.py
@@ -126,7 +126,7 @@ def test_verification_after_node_restart(l1_client, l2_client_node1, catalyst_no
     wait_for_batch_proposed_event(l1_client, env_vars.taiko_inbox_address, current_block)
 
 def test_end_of_sequencing(l2_client_node1, beacon_client, l1_client, env_vars):
-    wait_for_epoch_with_operator_switch_and_slot(beacon_client, l1_client, env_vars.preconf_whitelist_address, 24) # handover window
+    wait_for_epoch_with_operator_switch_and_slot(beacon_client, l1_client, env_vars.preconf_whitelist_address, 25) # handover window
 
     l2_block_number = l2_client_node1.eth.block_number
     send_n_txs_without_waiting(l2_client_node1, env_vars.l2_prefunded_priv_key, env_vars.preconf_min_txs)

--- a/e2e_tests/test_forced_inclusion.py
+++ b/e2e_tests/test_forced_inclusion.py
@@ -345,7 +345,7 @@ def test_verify_forced_inclusion_after_previous_operator_stop(l1_client, beacon_
         stop_catalyst_node(node_number)
 
         # wait for handower window
-        wait_for_slot_beginning(beacon_client, 24)
+        wait_for_slot_beginning(beacon_client, 25)
         in_handover_block_number = l2_client_node1.eth.block_number
         print("In handover block number:", in_handover_block_number)
 


### PR DESCRIPTION
We should skip slot 24 because of handover buffer
```sh
2025-10-02T11:14:13.014945Z | Epoch: 102    | Slot: 24 | L2 Slot: 0  | Txs: 0    | Fee: 25000000 | L2: 857    | Time: 1759403653 | Hash: 0x314782 | Batches: 0 | No active roles |
2025-10-02T11:14:15.011537Z | Epoch: 102    | Slot: 24 | L2 Slot: 1  | Txs: 1    | Fee: 25000000 | L2: 857    | Time: 1759403655 | Hash: 0x314782 | Batches: 0 | No active roles |
2025-10-02T11:14:17.011247Z | Epoch: 102    | Slot: 24 | L2 Slot: 2  | Txs: 1    | Fee: 25000000 | L2: 857    | Time: 1759403657 | Hash: 0x314782 | Batches: 0 | No active roles |
2025-10-02T11:14:19.013099Z | Epoch: 102    | Slot: 24 | L2 Slot: 3  | Txs: 2    | Fee: 25000000 | L2: 857    | Time: 1759403659 | Hash: 0x314782 | Batches: 0 | Preconf, Synced |
# add block
2025-10-02T11:14:19.044134Z  INFO catalyst_whitelist::chain_monitor: L2 block → number: 858, hash: 0xbf9917cb0509b8a077aa376e48504e388205d833066dd9273992773c9ac980ce, parent hash: 0x3147822f72ad91eaff3807898f1daf7c7369489754f65e59824f4ab258d4a29e
2025-10-02T11:14:21.011656Z | Epoch: 102    | Slot: 24 | L2 Slot: 4  | Txs: 0    | Fee: 25000000 | L2: 858    | Time: 1759403661 | Hash: 0xbf9917 | Batches: 1 | Preconf, Synced |

```