### PR TITLE
Shasta anchor tx construct method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-boot-node"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "discv5",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-network"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "discv5",
  "futures",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-node"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -4702,7 +4702,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "permissionless"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6800,7 +6800,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "urc"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -7103,7 +7103,7 @@ dependencies = [
 
 [[package]]
 name = "whitelist"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "alloy",
  "alloy-json-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 default-members = ["whitelist"]
 
 [workspace.package]
-version = "1.11.0"
+version = "1.12.0"
 edition = "2024"
 repository = "https://github.com/NethermindEth/Catalyst"
 license = "MIT"

--- a/common/src/l1/shasta/bindings.rs
+++ b/common/src/l1/shasta/bindings.rs
@@ -49,22 +49,7 @@ pub mod iinbox {
         function validateBlobReference(BlobReference memory _blobReference)
             internal
             view
-            returns (BlobSlice memory)
-        {
-            require(_blobReference.numBlobs > 0, NoBlobs());
-
-            bytes32[] memory blobHashes = new bytes32[](_blobReference.numBlobs);
-            for (uint256 i; i < _blobReference.numBlobs; ++i) {
-                blobHashes[i] = blobhash(_blobReference.blobStartIndex + i);
-                require(blobHashes[i] != 0, BlobNotFound());
-            }
-
-            return BlobSlice({
-                blobHashes: blobHashes,
-                offset: _blobReference.offset,
-                timestamp: uint48(block.timestamp)
-            });
-        }
+            returns (BlobSlice memory);
 
         // ---------------------------------------------------------------
         // Errors
@@ -74,21 +59,12 @@ pub mod iinbox {
         error NoBlobs();
     }
 
-
     library LibBonds {
-        // ---------------------------------------------------------------
-        // Enums
-        // ---------------------------------------------------------------
-
         enum BondType {
             NONE,
             PROVABILITY,
             LIVENESS
         }
-
-        // ---------------------------------------------------------------
-        // Structs
-        // ---------------------------------------------------------------
 
         struct BondInstruction {
             uint48 proposalId;
@@ -96,25 +72,14 @@ pub mod iinbox {
             address payer;
             address payee;
         }
-
-        // ---------------------------------------------------------------
-        // Internal Functions
-        // ---------------------------------------------------------------
-
         function aggregateBondInstruction(
             bytes32 _bondInstructionsHash,
             BondInstruction memory _bondInstruction
         )
             internal
             pure
-            returns (bytes32)
-        {
-            return _bondInstruction.proposalId == 0 || _bondInstruction.bondType == BondType.NONE
-                ? _bondInstructionsHash
-                : keccak256(abi.encode(_bondInstructionsHash, _bondInstruction));
-        }
+            returns (bytes32);
     }
-
 
     interface ICheckpointStore {
         // ---------------------------------------------------------------

--- a/common/src/l2/config.rs
+++ b/common/src/l2/config.rs
@@ -49,7 +49,7 @@ impl TaikoConfig {
         rpc_driver_preconf_timeout: Duration,
         rpc_driver_status_timeout: Duration,
         singer: Arc<Signer>,
-        protocol: Fork,
+        fork: Fork,
     ) -> Result<Self, Error> {
         Ok(Self {
             taiko_geth_url: taiko_geth_ws_url,
@@ -65,7 +65,7 @@ impl TaikoConfig {
             rpc_driver_preconf_timeout,
             rpc_driver_status_timeout,
             signer: singer,
-            fork: protocol,
+            fork,
         })
     }
 }

--- a/common/src/l2/config.rs
+++ b/common/src/l2/config.rs
@@ -1,4 +1,4 @@
-use crate::signer::Signer;
+use crate::{shared::fork::Fork, signer::Signer};
 use alloy::primitives::{Address, B256};
 use anyhow::Error;
 use std::str::FromStr;
@@ -30,6 +30,7 @@ pub struct TaikoConfig {
     pub rpc_driver_preconf_timeout: Duration,
     pub rpc_driver_status_timeout: Duration,
     pub signer: Arc<Signer>,
+    pub fork: Fork,
 }
 
 impl TaikoConfig {
@@ -48,6 +49,7 @@ impl TaikoConfig {
         rpc_driver_preconf_timeout: Duration,
         rpc_driver_status_timeout: Duration,
         singer: Arc<Signer>,
+        protocol: Fork,
     ) -> Result<Self, Error> {
         Ok(Self {
             taiko_geth_url: taiko_geth_ws_url,
@@ -63,6 +65,7 @@ impl TaikoConfig {
             rpc_driver_preconf_timeout,
             rpc_driver_status_timeout,
             signer: singer,
+            fork: protocol,
         })
     }
 }

--- a/common/src/l2/execution_layer.rs
+++ b/common/src/l2/execution_layer.rs
@@ -325,6 +325,7 @@ impl L2ExecutionLayer {
 
     pub async fn construct_anchor_tx(
         &self,
+        preconfer_address: Address,
         l2_slot_info: &L2SlotInfo,
         anchor_block_id: u64,
         anchor_state_root: B256,
@@ -348,7 +349,7 @@ impl L2ExecutionLayer {
                 shasta_execution_layer
                     .construct_anchor_tx(
                         // proposal_id,
-                        // proposer,
+                        preconfer_address,
                         u16::try_from(l2_slot_info.parent_id()).map_err(|e| {
                             anyhow::anyhow!("Failed to convert parent id to u16: {}", e)
                         })?,

--- a/common/src/l2/execution_layer.rs
+++ b/common/src/l2/execution_layer.rs
@@ -1,59 +1,68 @@
 use super::{
     bindings::{Bridge, LibSharedData, TaikoAnchor},
-    config::{GOLDEN_TOUCH_ADDRESS, GOLDEN_TOUCH_PRIVATE_KEY, TaikoConfig},
+    config::TaikoConfig,
+    pacaya::execution_layer::ExecutionLayer as PacayaExecutionLayer,
+    shasta::execution_layer::ExecutionLayer as ShastaExecutionLayer,
 };
-use crate::shared::alloy_tools;
+use crate::shared::{alloy_tools, fork::Fork};
 use alloy::{
-    consensus::{
-        SignableTransaction, Transaction as AnchorTransaction, TxEnvelope, transaction::Recovered,
-    },
-    contract::Error as ContractError,
+    consensus::Transaction as AnchorTransaction,
     eips::BlockNumberOrTag,
     network::ReceiptResponse,
     primitives::{Address, B256, Bytes, U256, Uint},
     providers::{DynProvider, Provider},
     rpc::types::{Block as RpcBlock, Transaction},
-    signers::Signature,
-    transports::TransportErrorKind,
 };
-use alloy_json_rpc::RpcError;
 use anyhow::Error;
 use serde_json::Value;
 use std::time::Duration;
-use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
+enum L2ForkExecutionLayer {
+    Pacaya(PacayaExecutionLayer),
+    Shasta(ShastaExecutionLayer),
+}
+
 pub struct L2ExecutionLayer {
-    provider: RwLock<DynProvider>,
-    taiko_anchor: RwLock<TaikoAnchor::TaikoAnchorInstance<DynProvider>>,
+    provider: DynProvider,
+    taiko_anchor: TaikoAnchor::TaikoAnchorInstance<DynProvider>,
     chain_id: u64,
     config: TaikoConfig,
+    l2_fork: L2ForkExecutionLayer,
 }
 
 impl L2ExecutionLayer {
     pub async fn new(taiko_config: TaikoConfig) -> Result<Self, Error> {
-        let provider = RwLock::new(
-            alloy_tools::create_alloy_provider_without_wallet(&taiko_config.taiko_geth_url).await?,
-        );
+        let provider =
+            alloy_tools::create_alloy_provider_without_wallet(&taiko_config.taiko_geth_url).await?;
 
         let chain_id = provider
-            .read()
-            .await
             .get_chain_id()
             .await
             .map_err(|e| anyhow::anyhow!("Failed to get chain ID: {}", e))?;
         info!("L2 Chain ID: {}", chain_id);
 
-        let taiko_anchor = RwLock::new(TaikoAnchor::new(
-            taiko_config.taiko_anchor_address,
-            provider.read().await.clone(),
-        ));
+        let taiko_anchor = TaikoAnchor::new(taiko_config.taiko_anchor_address, provider.clone());
+
+        let l2_fork = match taiko_config.fork {
+            Fork::Pacaya => L2ForkExecutionLayer::Pacaya(PacayaExecutionLayer::new(
+                provider.clone(),
+                taiko_config.taiko_anchor_address,
+                chain_id,
+            )),
+            Fork::Shasta => L2ForkExecutionLayer::Shasta(ShastaExecutionLayer::new(
+                provider.clone(),
+                taiko_config.taiko_anchor_address,
+                chain_id,
+            )),
+        };
 
         Ok(Self {
             provider,
             taiko_anchor,
             chain_id,
             config: taiko_config,
+            l2_fork,
         })
     }
 
@@ -65,59 +74,47 @@ impl L2ExecutionLayer {
     }
 
     pub async fn get_l2_block_header(&self, block: BlockNumberOrTag) -> Result<RpcBlock, Error> {
-        let block_by_number = self.provider.read().await.get_block_by_number(block).await;
-
-        self.check_for_provider_failure(block_by_number, "Failed to get latest L2 block")
-            .await?
-            .ok_or(anyhow::anyhow!("Failed to get latest L2 block"))
+        self.provider
+            .get_block_by_number(block)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get L2 block header: {}", e))?
+            .ok_or(anyhow::anyhow!("Failed to get L2 block header"))
     }
 
     async fn get_latest_l2_block_with_txs(&self) -> Result<RpcBlock, Error> {
-        let block_by_number = self
-            .provider
-            .read()
-            .await
+        self.provider
             .get_block_by_number(BlockNumberOrTag::Latest)
             .full()
-            .await;
-
-        self.check_for_provider_failure(block_by_number, "Failed to get latest L2 block")
-            .await?
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get latest L2 block: {}", e))?
             .ok_or(anyhow::anyhow!("Failed to get latest L2 block"))
     }
 
     pub async fn get_balance(&self, address: Address) -> Result<U256, Error> {
-        let balance = self.provider.read().await.get_balance(address).await;
-        self.check_for_provider_failure(balance, "Failed to get L2 balance")
+        self.provider
+            .get_balance(address)
             .await
+            .map_err(|e| anyhow::anyhow!("Failed to get L2 balance: {}", e))
     }
 
     pub async fn get_forced_inclusion_form_l1origin(&self, block_id: u64) -> Result<bool, Error> {
-        let result = self
-            .provider
-            .read()
-            .await
-            .raw_request(
+        self.provider
+            .raw_request::<_, Value>(
                 std::borrow::Cow::Borrowed("taiko_l1OriginByID"),
                 vec![Value::String(block_id.to_string())],
             )
-            .await;
-
-        let is_forced_inclusion: bool = self
-            .check_for_provider_failure::<Value>(result, "Failed to get forced inclusion")
-            .await?
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get forced inclusion: {}", e))?
             .get("isForcedInclusion")
             .and_then(Value::as_bool)
-            .ok_or_else(|| anyhow::anyhow!("Failed to parse isForcedInclusion"))?;
-
-        Ok(is_forced_inclusion)
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse isForcedInclusion"))
     }
 
     pub async fn get_latest_l2_block_id(&self) -> Result<u64, Error> {
-        let block_number = self.provider.read().await.get_block_number().await;
-
-        self.check_for_provider_failure(block_number, "Failed to get latest L2 block number")
+        self.provider
+            .get_block_number()
             .await
+            .map_err(|e| anyhow::anyhow!("Failed to get latest L2 block number: {}", e))
     }
 
     pub async fn get_l2_block_by_number(
@@ -127,104 +124,32 @@ impl L2ExecutionLayer {
     ) -> Result<alloy::rpc::types::Block, Error> {
         let mut block_by_number = self
             .provider
-            .read()
-            .await
             .get_block_by_number(BlockNumberOrTag::Number(number));
 
         if full_txs {
             block_by_number = block_by_number.full();
         }
 
-        let block = self
-            .check_for_provider_failure(block_by_number.await, "Failed to get L2 block by number")
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Failed to get L2 block {}: value was None", number))?;
-        Ok(block)
-    }
-
-    pub async fn construct_anchor_tx(
-        &self,
-        parent_hash: B256,
-        anchor_block_id: u64,
-        anchor_state_root: B256,
-        parent_gas_used: u32,
-        base_fee_config: LibSharedData::BaseFeeConfig,
-        base_fee: u64,
-    ) -> Result<Transaction, Error> {
-        // Create the contract call
-        let taiko_anchor = self.taiko_anchor.read().await;
-        let tx_count_result = self
-            .provider
-            .read()
+        block_by_number
             .await
-            .get_transaction_count(GOLDEN_TOUCH_ADDRESS)
-            .block_id(parent_hash.into())
-            .await;
-        let nonce = self
-            .check_for_provider_failure(tx_count_result, "Failed to get nonce")
-            .await?;
-        let call_builder = taiko_anchor
-            .anchorV3(
-                anchor_block_id,
-                anchor_state_root,
-                parent_gas_used,
-                base_fee_config,
-                vec![],
-            )
-            .gas(1_000_000) // value expected by Taiko
-            .max_fee_per_gas(u128::from(base_fee)) // value expected by Taiko
-            .max_priority_fee_per_gas(0) // value expected by Taiko
-            .nonce(nonce)
-            .chain_id(self.chain_id);
-
-        let typed_tx = call_builder
-            .into_transaction_request()
-            .build_typed_tx()
-            .map_err(|_| anyhow::anyhow!("AnchorTX: Failed to build typed transaction"))?;
-
-        let tx_eip1559 = typed_tx
-            .eip1559()
-            .ok_or_else(|| anyhow::anyhow!("AnchorTX: Failed to extract EIP-1559 transaction"))?;
-
-        let signature = self.sign_hash_deterministic(tx_eip1559.signature_hash())?;
-        let sig_tx = tx_eip1559.clone().into_signed(signature);
-
-        let tx_envelope = TxEnvelope::from(sig_tx);
-
-        debug!("AnchorTX transaction hash: {}", tx_envelope.tx_hash());
-
-        let tx = Transaction {
-            inner: Recovered::new_unchecked(tx_envelope, GOLDEN_TOUCH_ADDRESS),
-            block_hash: None,
-            block_number: None,
-            transaction_index: None,
-            effective_gas_price: None,
-        };
-        Ok(tx)
-    }
-
-    fn sign_hash_deterministic(&self, hash: B256) -> Result<Signature, Error> {
-        crate::crypto::fixed_k_signer::sign_hash_deterministic(GOLDEN_TOUCH_PRIVATE_KEY, hash)
+            .map_err(|e| anyhow::anyhow!("Failed to get L2 block by number: {}", e))?
+            .ok_or(anyhow::anyhow!(
+                "Failed to get L2 block {}: value was None",
+                number
+            ))
     }
 
     pub async fn get_transaction_by_hash(
         &self,
         hash: B256,
     ) -> Result<alloy::rpc::types::Transaction, Error> {
-        let transaction_by_hash = self
-            .provider
-            .read()
-            .await
+        self.provider
             .get_transaction_by_hash(hash)
-            .await;
-
-        let transaction = self
-            .check_for_provider_failure(transaction_by_hash, "Failed to get L2 transaction by hash")
-            .await?
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get L2 transaction by hash: {}", e))?
             .ok_or(anyhow::anyhow!(
                 "Failed to get L2 transaction: value is None"
-            ))?;
-        Ok(transaction)
+            ))
     }
 
     pub async fn get_base_fee(
@@ -234,17 +159,13 @@ impl L2ExecutionLayer {
         base_fee_config: LibSharedData::BaseFeeConfig,
         l2_slot_timestamp: u64,
     ) -> Result<u64, Error> {
-        let base_fee_v2_result = self
+        let base_fee = self
             .taiko_anchor
-            .read()
-            .await
             .getBasefeeV2(parent_gas_used, l2_slot_timestamp, base_fee_config)
             .block(parent_hash.into())
             .call()
-            .await;
-        let base_fee = self
-            .check_for_contract_failure(base_fee_v2_result, "Failed to get base fee")
-            .await?
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get base fee: {}", e))?
             .basefee_;
 
         base_fee
@@ -253,15 +174,11 @@ impl L2ExecutionLayer {
     }
 
     pub async fn get_last_synced_anchor_block_id_from_taiko_anchor(&self) -> Result<u64, Error> {
-        let last_synced_block = self
-            .taiko_anchor
-            .read()
-            .await
+        self.taiko_anchor
             .lastSyncedBlock()
             .call()
-            .await;
-        self.check_for_contract_failure(last_synced_block, "Failed to get last synced block")
             .await
+            .map_err(|e| anyhow::anyhow!("Failed to get last synced block: {}", e))
     }
 
     pub async fn get_last_synced_anchor_block_id_from_geth(&self) -> Result<u64, Error> {
@@ -406,58 +323,42 @@ impl L2ExecutionLayer {
         Ok(())
     }
 
-    /// Warning: be sure not to `read` from the rwlock
-    /// while passing parameters to this function
-    async fn check_for_provider_failure<T>(
+    pub async fn construct_anchor_tx(
         &self,
-        result: Result<T, RpcError<TransportErrorKind>>,
-        error_message: &str,
-    ) -> Result<T, Error> {
-        match result {
-            Ok(result) => Ok(result),
-            Err(e) => {
-                self.recreate_provider().await?;
-                Err(anyhow::anyhow!(
-                    "{}. Recreating WebSocket provider. Transport error: {}",
-                    error_message,
-                    e
-                ))
+        parent_hash: B256,
+        anchor_block_id: u64,
+        anchor_state_root: B256,
+        parent_gas_used: u32,
+        base_fee_config: LibSharedData::BaseFeeConfig,
+        base_fee: u64,
+    ) -> Result<Transaction, Error> {
+        match &self.l2_fork {
+            L2ForkExecutionLayer::Pacaya(pacaya_execution_layer) => {
+                pacaya_execution_layer
+                    .construct_anchor_tx(
+                        parent_hash,
+                        anchor_block_id,
+                        anchor_state_root,
+                        parent_gas_used,
+                        base_fee_config,
+                        base_fee,
+                    )
+                    .await
+            }
+            L2ForkExecutionLayer::Shasta(shasta_execution_layer) => {
+                // TODO: propagate needed parameters for shasta anchor tx
+                shasta_execution_layer
+                    .construct_anchor_tx(
+                        // proposal_id,
+                        // proposer,
+                        // l2_block_number,
+                        parent_hash,
+                        anchor_block_id,
+                        anchor_state_root,
+                        base_fee,
+                    )
+                    .await
             }
         }
-    }
-
-    /// Warning: be sure not to `read` from the rwlock
-    /// while passing parameters to this function
-    async fn check_for_contract_failure<T>(
-        &self,
-        result: Result<T, ContractError>,
-        error_message: &str,
-    ) -> Result<T, Error> {
-        match result {
-            Ok(result) => Ok(result),
-            Err(ContractError::TransportError(e)) => {
-                self.recreate_provider().await?;
-                Err(anyhow::anyhow!(
-                    "{}. Recreating WebSocket provider. Transport error: {}",
-                    error_message,
-                    e
-                ))
-            }
-            Err(e) => Err(anyhow::anyhow!("{}: {}", error_message, e)),
-        }
-    }
-
-    async fn recreate_provider(&self) -> Result<(), Error> {
-        let provider =
-            alloy_tools::create_alloy_provider_without_wallet(&self.config.taiko_geth_url).await?;
-
-        *self.taiko_anchor.write().await =
-            TaikoAnchor::new(self.config.taiko_anchor_address, provider.clone());
-        *self.provider.write().await = provider;
-        debug!(
-            "Created new WebSocket provider for {}",
-            self.config.taiko_geth_url
-        );
-        Ok(())
     }
 }

--- a/common/src/l2/mod.rs
+++ b/common/src/l2/mod.rs
@@ -3,4 +3,5 @@ pub mod config;
 mod execution_layer;
 pub mod operation_type;
 pub mod preconf_blocks;
+pub mod shasta;
 pub mod taiko;

--- a/common/src/l2/mod.rs
+++ b/common/src/l2/mod.rs
@@ -2,6 +2,7 @@ mod bindings;
 pub mod config;
 mod execution_layer;
 pub mod operation_type;
+mod pacaya;
 pub mod preconf_blocks;
-pub mod shasta;
+mod shasta;
 pub mod taiko;

--- a/common/src/l2/pacaya/mod.rs
+++ b/common/src/l2/pacaya/mod.rs
@@ -1,2 +1,1 @@
-mod bindings;
 pub mod execution_layer;

--- a/common/src/l2/shasta/bindings.rs
+++ b/common/src/l2/shasta/bindings.rs
@@ -1,0 +1,59 @@
+#![allow(clippy::too_many_arguments)]
+
+use alloy::sol;
+
+sol! {
+
+    library LibBonds {
+        enum BondType {
+            NONE,
+            PROVABILITY,
+            LIVENESS
+        }
+
+        struct BondInstruction {
+            uint48 proposalId;
+            BondType bondType;
+            address payer;
+            address payee;
+        }
+        function aggregateBondInstruction(
+            bytes32 _bondInstructionsHash,
+            BondInstruction memory _bondInstruction
+        )
+            internal
+            pure
+            returns (bytes32);
+    }
+
+    #[sol(rpc)]
+    abstract contract ShastaAnchor {
+        struct State {
+            bytes32 bondInstructionsHash; // Latest known bond instructions hash
+            uint48 anchorBlockNumber; // Latest L1 block number anchored to L2
+            address designatedProver; // The prover designated for the current batch
+            bool isLowBondProposal; // Indicates if the proposal has insufficient bonds
+            uint48 endOfSubmissionWindowTimestamp; // The timestamp of the last slot where the current
+                // preconfer can submit preconf-ed blocks to the L2 network.
+        }
+
+        function updateState(
+            // Proposal level fields - define the overall batch
+            uint48 _proposalId,
+            address _proposer,
+            bytes calldata _proverAuth,
+            bytes32 _bondInstructionsHash,
+            LibBonds.BondInstruction[] calldata _bondInstructions,
+            // Block level fields - specific to this block in the proposal
+            uint16 _blockIndex,
+            uint48 _anchorBlockNumber,
+            bytes32 _anchorBlockHash,
+            bytes32 _anchorStateRoot,
+            uint48 _endOfSubmissionWindowTimestamp
+        )
+            external
+            onlyGoldenTouch
+            nonReentrant
+            returns (State memory previousState_, State memory newState_);
+    }
+}

--- a/common/src/l2/shasta/execution_layer.rs
+++ b/common/src/l2/shasta/execution_layer.rs
@@ -1,0 +1,104 @@
+use super::super::config::GOLDEN_TOUCH_ADDRESS;
+use super::bindings::ShastaAnchor;
+use alloy::{
+    consensus::{SignableTransaction, TxEnvelope, transaction::Recovered},
+    primitives::{Address, B256, Bytes, FixedBytes, Uint},
+    providers::{DynProvider, Provider},
+    rpc::types::Transaction,
+    signers::Signature,
+};
+use anyhow::Error;
+use tracing::debug;
+
+struct ExecutionLayer {
+    provider: DynProvider,
+    shasta_anchor: ShastaAnchor::ShastaAnchorInstance<DynProvider>,
+    chain_id: u64,
+}
+
+impl ExecutionLayer {
+    pub fn new(provider: DynProvider, shasta_anchor_address: Address, chain_id: u64) -> Self {
+        let shasta_anchor = ShastaAnchor::new(shasta_anchor_address, provider.clone());
+        Self {
+            provider,
+            shasta_anchor,
+            chain_id,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn construct_anchor_tx(
+        &self,
+        proposal_id: u64,
+        proposer: Address,
+        // bond_instructions_hash: B256,
+        // bond_instructions: Vec<BondInstruction>,
+        l2_block_number: u16,
+        parent_hash: B256,
+        anchor_block_id: u64,
+        anchor_block_hash: B256,
+        anchor_state_root: B256,
+        // parent_gas_used: u32,
+        // base_fee_config: LibSharedData::BaseFeeConfig,
+        base_fee: u64,
+    ) -> Result<Transaction, Error> {
+        let nonce = self
+            .provider
+            .get_transaction_count(GOLDEN_TOUCH_ADDRESS)
+            .block_id(parent_hash.into())
+            .await?;
+        let call_builder = self
+            .shasta_anchor
+            .updateState(
+                Uint::<48, 1>::from(proposal_id),
+                proposer,
+                Bytes::new(),                // no prover designation
+                FixedBytes::from([0u8; 32]), // bond_instructions_hash, take them from the indexer
+                vec![],
+                l2_block_number,
+                Uint::<48, 1>::from(anchor_block_id),
+                anchor_block_hash,
+                anchor_state_root,
+                Uint::<48, 1>::from(0), // 0 for whitelist
+            )
+            .gas(1_000_000) // value expected by Taiko
+            .max_fee_per_gas(u128::from(base_fee)) // value expected by Taiko
+            .max_priority_fee_per_gas(0) // value expected by Taiko
+            .nonce(nonce)
+            .chain_id(self.chain_id);
+
+        let typed_tx = call_builder
+            .into_transaction_request()
+            .build_typed_tx()
+            .map_err(|_| anyhow::anyhow!("AnchorTX: Failed to build typed transaction"))?;
+
+        let tx_eip1559 = typed_tx
+            .eip1559()
+            .ok_or_else(|| anyhow::anyhow!("AnchorTX: Failed to extract EIP-1559 transaction"))?;
+
+        let signature = self.sign_hash_deterministic(tx_eip1559.signature_hash())?;
+        let sig_tx = tx_eip1559.clone().into_signed(signature);
+
+        let tx_envelope = TxEnvelope::from(sig_tx);
+
+        debug!("AnchorTX transaction hash: {}", tx_envelope.tx_hash());
+
+        // Transaction::from
+
+        let tx = Transaction {
+            inner: Recovered::new_unchecked(tx_envelope, GOLDEN_TOUCH_ADDRESS),
+            block_hash: None,
+            block_number: None,
+            transaction_index: None,
+            effective_gas_price: None,
+        };
+        Ok(tx)
+    }
+
+    fn sign_hash_deterministic(&self, hash: B256) -> Result<Signature, Error> {
+        crate::crypto::fixed_k_signer::sign_hash_deterministic(
+            super::super::config::GOLDEN_TOUCH_PRIVATE_KEY,
+            hash,
+        )
+    }
+}

--- a/common/src/l2/shasta/execution_layer.rs
+++ b/common/src/l2/shasta/execution_layer.rs
@@ -79,8 +79,6 @@ impl ExecutionLayer {
 
         debug!("AnchorTX transaction hash: {}", tx_envelope.tx_hash());
 
-        // Transaction::from
-
         let tx = Transaction {
             inner: Recovered::new_unchecked(tx_envelope, GOLDEN_TOUCH_ADDRESS),
             block_hash: None,

--- a/common/src/l2/shasta/execution_layer.rs
+++ b/common/src/l2/shasta/execution_layer.rs
@@ -31,7 +31,7 @@ impl ExecutionLayer {
         &self,
         // proposal_id: u64,    // TODO: implement
         // proposer: Address,
-        // l2_block_number: u16,
+        l2_block_number: u16,
         parent_hash: B256,
         anchor_block_id: u64,
         // anchor_block_hash: B256,
@@ -51,7 +51,7 @@ impl ExecutionLayer {
                 Bytes::new(),                // no prover designation
                 FixedBytes::from([0u8; 32]), // bond_instructions_hash, take them from the indexer
                 vec![],
-                0, // l2_block_number,
+                l2_block_number,
                 Uint::<48, 1>::from(anchor_block_id),
                 B256::ZERO, // anchor_block_hash,
                 anchor_state_root,

--- a/common/src/l2/shasta/execution_layer.rs
+++ b/common/src/l2/shasta/execution_layer.rs
@@ -30,7 +30,7 @@ impl ExecutionLayer {
     pub async fn construct_anchor_tx(
         &self,
         // proposal_id: u64,    // TODO: implement
-        // proposer: Address,
+        proposer: Address,
         l2_block_number: u16,
         parent_hash: B256,
         anchor_block_id: u64,
@@ -46,8 +46,8 @@ impl ExecutionLayer {
         let call_builder = self
             .shasta_anchor
             .updateState(
-                Uint::<48, 1>::from(0),      // proposal_id
-                Address::ZERO,               // proposer
+                Uint::<48, 1>::from(0), // proposal_id
+                proposer,
                 Bytes::new(),                // no prover designation
                 FixedBytes::from([0u8; 32]), // bond_instructions_hash, take them from the indexer
                 vec![],

--- a/common/src/l2/shasta/mod.rs
+++ b/common/src/l2/shasta/mod.rs
@@ -1,0 +1,2 @@
+mod bindings;
+mod execution_layer;

--- a/common/src/l2/taiko.rs
+++ b/common/src/l2/taiko.rs
@@ -272,12 +272,10 @@ impl<ELE: ELTrait> Taiko<ELE> {
         let anchor_tx = self
             .l2_execution_layer
             .construct_anchor_tx(
-                *l2_slot_info.parent_hash(),
+                l2_slot_info,
                 anchor_origin_height,
                 anchor_block_state_root,
-                l2_slot_info.parent_gas_used(),
                 base_fee_config.clone(),
-                l2_slot_info.base_fee(),
             )
             .await?;
         let tx_list = std::iter::once(anchor_tx)

--- a/common/src/l2/taiko.rs
+++ b/common/src/l2/taiko.rs
@@ -272,6 +272,10 @@ impl<ELE: ELTrait> Taiko<ELE> {
         let anchor_tx = self
             .l2_execution_layer
             .construct_anchor_tx(
+                self.ethereum_l1
+                    .execution_layer
+                    .common()
+                    .get_preconfer_alloy_address(),
                 l2_slot_info,
                 anchor_origin_height,
                 anchor_block_state_root,

--- a/common/src/shared/fork.rs
+++ b/common/src/shared/fork.rs
@@ -1,0 +1,28 @@
+use anyhow::Error;
+use std::{
+    fmt::{Display, Formatter, Result},
+    str::FromStr,
+};
+
+#[derive(Clone, Debug)]
+pub enum Fork {
+    Pacaya,
+    Shasta,
+}
+
+impl Display for Fork {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl FromStr for Fork {
+    type Err = Error;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "pacaya" => Ok(Fork::Pacaya),
+            "shasta" => Ok(Fork::Shasta),
+            _ => Err(Error::msg(format!("Invalid fork: {}", s))),
+        }
+    }
+}

--- a/common/src/shared/mod.rs
+++ b/common/src/shared/mod.rs
@@ -1,4 +1,5 @@
 pub mod alloy_tools;
+pub mod fork;
 pub mod l2_block;
 pub mod l2_slot_info;
 pub mod l2_tx_lists;

--- a/whitelist/src/main.rs
+++ b/whitelist/src/main.rs
@@ -112,6 +112,7 @@ async fn main() -> Result<(), Error> {
                 config.rpc_driver_preconf_timeout,
                 config.rpc_driver_status_timeout,
                 l2_signer,
+                config.specific_config.fork,
             )?,
         )
         .await

--- a/whitelist/src/utils/config.rs
+++ b/whitelist/src/utils/config.rs
@@ -1,3 +1,4 @@
+use common::shared::fork::Fork;
 use common::utils::config_trait::ConfigTrait;
 use tracing::warn;
 
@@ -18,6 +19,7 @@ pub struct Config {
     pub l1_height_lag: u64,
     pub propose_forced_inclusion: bool,
     pub simulate_not_submitting_at_the_end_of_epoch: bool,
+    pub fork: Fork,
 }
 
 impl ConfigTrait for Config {
@@ -69,6 +71,11 @@ impl ConfigTrait for Config {
                 .parse::<bool>()
                 .expect("SIMULATE_NOT_SUBMITTING_AT_THE_END_OF_EPOCH must be a boolean");
 
+        let fork = std::env::var("FORK")
+            .unwrap_or("pacaya".to_string())
+            .parse::<Fork>()
+            .expect("FORK must be a valid fork");
+
         Config {
             contract_addresses: L1ContractAddresses {
                 taiko_inbox,
@@ -82,6 +89,7 @@ impl ConfigTrait for Config {
             l1_height_lag,
             propose_forced_inclusion,
             simulate_not_submitting_at_the_end_of_epoch,
+            fork,
         }
     }
 }
@@ -107,7 +115,7 @@ impl fmt::Display for Config {
             "simulate not submitting at the end of epoch: {}",
             self.simulate_not_submitting_at_the_end_of_epoch
         )?;
-
+        writeln!(f, "protocol: {}", self.fork)?;
         Ok(())
     }
 }

--- a/whitelist/src/utils/config.rs
+++ b/whitelist/src/utils/config.rs
@@ -115,7 +115,7 @@ impl fmt::Display for Config {
             "simulate not submitting at the end of epoch: {}",
             self.simulate_not_submitting_at_the_end_of_epoch
         )?;
-        writeln!(f, "protocol: {}", self.fork)?;
+        writeln!(f, "fork: {}", self.fork)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Separated shasta and pacaya construction methods.
Removed unneeded RwLock from L2ExecutionLayer. It wasn't needed after alloy handles better websocket disconnection errors.

Some `updateState` and `construct_anchor_tx` arguments still need to be added. Part of them will come from the indexer and part of them need to be propagated from higher levels of code.